### PR TITLE
readme: Remove mentions of Gmail's "less secure app access"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1150,17 +1150,12 @@ In order to enable IMAP access go to the Gmail web interface - typically
 
 ### Password Authentication
 Gmail prevents password authentication by default. To enable
-password-authenticated IMAP access, one must either set up an "app password"
-or enable "less secure app access".
+password-authenticated IMAP access, one must set up an "app password".
 
 To set up an "app password", navigate to
 [https://myaccount.google.com/apppasswords](https://myaccount.google.com/apppasswords)
 and select app "Mail" and an appropriate device, e.g. "Mac", then click
 Generate.
-
-To enable "less secure app access", go to
-[myaccount.google.com/security](https://myaccount.google.com/security) and
-under `Less secure app access` click `Turn on access (not recommended)`.
 
 ### OAuth 2.0 Authentication
 Google OAuth 2.0 application review has not yet been requested for nmail, and


### PR DESCRIPTION
It is no longer supported.
Closes #162.